### PR TITLE
fix: use any type for OpenapiClient methods to handle never contravariance

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,11 +1,11 @@
 import { error as svelteError } from '@sveltejs/kit';
 
 interface OpenapiClient {
-  GET: (...args: any[]) => Promise<any>;
-  POST: (...args: any[]) => Promise<any>;
-  PATCH: (...args: any[]) => Promise<any>;
-  PUT: (...args: any[]) => Promise<any>;
-  DELETE: (...args: any[]) => Promise<any>;
+  GET: any;
+  POST: any;
+  PATCH: any;
+  PUT: any;
+  DELETE: any;
 }
 
 function handleResponse(response: any, error: any, data: any) {


### PR DESCRIPTION
## Summary
- When an openapi-fetch `Client<paths>` has no endpoints for a given HTTP method (e.g., no PUT routes), that method's type resolves to `(url: never) => Promise<any>` due to TypeScript contravariance
- `(...args: any[]) => Promise<any>` isn't assignable from `(url: never) => Promise<any>`, so using plain `any` for the method types avoids the issue entirely

## Test plan
- [x] `pnpm run build` passes
- [x] All 91 tests pass
- [ ] Verify a `Client<paths>` with missing HTTP methods is assignable to `OpenapiClient`