### PR TITLE
fix(runtime): forward a bare body on PATCH/PUT like POST

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sveltekit-openapi-remote",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Generate SvelteKit remote functions directly from OpenAPI/Swagger specs.",
   "type": "module",
   "license": "MIT",

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -43,9 +43,12 @@ export function createRemoteHandlers(client: OpenapiClient) {
   async function handlePatchCommand(path: string, input: any) {
     const hasPath = input && typeof input === 'object' && 'path' in input;
     const hasBody = input && typeof input === 'object' && 'body' in input;
+    // For a no-path endpoint the generated wrapper passes the body directly (no `body` key), so fall
+    // back to the whole input as the body — matching handlePostCommand. Without this, a bare body was
+    // silently dropped, sending an empty PATCH.
     const { data, error, response } = await client.PATCH(path, {
       ...(hasPath && { params: { path: input.path } }),
-      ...(hasBody && { body: input.body }),
+      body: hasBody ? input.body : input,
     });
     return handleResponse(response, error, data);
   }
@@ -53,9 +56,10 @@ export function createRemoteHandlers(client: OpenapiClient) {
   async function handlePutCommand(path: string, input: any) {
     const hasPath = input && typeof input === 'object' && 'path' in input;
     const hasBody = input && typeof input === 'object' && 'body' in input;
+    // Same bare-body fallback as handlePostCommand/handlePatchCommand.
     const { data, error, response } = await client.PUT(path, {
       ...(hasPath && { params: { path: input.path } }),
-      ...(hasBody && { body: input.body }),
+      body: hasBody ? input.body : input,
     });
     return handleResponse(response, error, data);
   }

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -117,6 +117,23 @@ describe('createRemoteHandlers', () => {
       });
       expect(result).toEqual({ updated: true });
     });
+
+    it('treats a bare body (no path/body key) as the request body, like POST', async () => {
+      // A no-path endpoint's generated wrapper passes the body directly (e.g. patchUsersCommand({...})).
+      // Regression: handlePatchCommand used to only forward input.body, silently dropping a bare body.
+      const client = createMockClient();
+      client.PATCH.mockResolvedValue({
+        data: { updated: true },
+        error: undefined,
+        response: { ok: true, status: 200 },
+      });
+      const { handlePatchCommand } = createRemoteHandlers(client as any);
+      const result = await handlePatchCommand('/users', { firstName: 'Tam', lastName: 'M' });
+      expect(client.PATCH).toHaveBeenCalledWith('/users', {
+        body: { firstName: 'Tam', lastName: 'M' },
+      });
+      expect(result).toEqual({ updated: true });
+    });
   });
 
   describe('handlePutCommand', () => {
@@ -137,6 +154,21 @@ describe('createRemoteHandlers', () => {
         body: { name: 'Replaced' },
       });
       expect(result).toEqual({ id: 1, name: 'Replaced' });
+    });
+
+    it('treats a bare body (no path/body key) as the request body, like POST', async () => {
+      const client = createMockClient();
+      client.PUT.mockResolvedValue({
+        data: { replaced: true },
+        error: undefined,
+        response: { ok: true, status: 200 },
+      });
+      const { handlePutCommand } = createRemoteHandlers(client as any);
+      const result = await handlePutCommand('/settings', { theme: 'dark' });
+      expect(client.PUT).toHaveBeenCalledWith('/settings', {
+        body: { theme: 'dark' },
+      });
+      expect(result).toEqual({ replaced: true });
     });
   });
 


### PR DESCRIPTION
## Problem

A no-path endpoint's generated command wrapper passes the request body **directly** (there is no `path`/`body` key), e.g. `patchUsersCommand({ firstName, lastName })`. But `handlePatchCommand`/`handlePutCommand` only forwarded `input.body`:

```ts
...(hasBody && { body: input.body }),
```

Since a bare body has no `body` key, `hasBody` is `false` and **the body was silently dropped** — an empty PATCH/PUT was sent. `handlePostCommand` already handled this correctly via a fallback (`body: hasBody ? input.body : input`), which is why POST worked but PATCH/PUT didn't on the same no-path shape.

Real-world impact: a profile-update form calling `patchUsersCommand({ firstName, lastName })` sent an empty request; the fields never reached the server.

## Fix

Make `handlePatchCommand` and `handlePutCommand` use the same bare-body fallback as `handlePostCommand`:

```ts
body: hasBody ? input.body : input,
```

- `{ path, body }` and `{ body }` shapes are unchanged (`hasBody` true → `input.body`).
- A bare body (`{ ...fields }`) is now forwarded as the request body.

## Tests

Added regression tests for both `handlePatchCommand` and `handlePutCommand` covering the bare-body (no path/body key) shape. Full suite: **93 passing**.

Bumps version to **0.1.7** so the publish workflow ships it.