### PR TITLE
ci(release): make publish version step idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,13 @@ jobs:
       - name: Set package version
         env:
           RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
-        run: npm version "$RELEASE_VERSION" --no-git-tag-version
+        run: |
+          current="$(node -p "require('./package.json').version")"
+          if [[ "$current" == "$RELEASE_VERSION" ]]; then
+            echo "package.json already at $RELEASE_VERSION; skipping bump."
+          else
+            npm version "$RELEASE_VERSION" --no-git-tag-version
+          fi
 
       - run: pnpm run build
 


### PR DESCRIPTION
## Problem

The 0.1.7 release failed at the **Set package version** step:

```
npm error Version not changed
Error: Process completed with exit code 1.
```

The version bump to 0.1.7 was committed alongside the bare-body fix (5bc4d0b), so `package.json` on `main` was already at 0.1.7 when the release ran. The publish job's `npm version 0.1.7 --no-git-tag-version` treats a no-op set as an error and fails the whole publish.

## Fix

Skip the bump when `package.json` is already at the target version, mirroring the `git diff --quiet` guard the `update-version` job already uses. After this merges, re-running the 0.1.7 release will publish cleanly.

## Going forward

Keep version bumps out of feature/fix commits — let the release workflow own them.