### PR TITLE
chore(dev): test against SvelteKit 2.69 (dev-dep only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@standard-schema/spec": "^1.1.0",
+    "@sveltejs/kit": "^2.69.3",
     "@types/node": "^25.5.0",
     "openapi-typescript": "^7.13.0",
     "typescript": "^5.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@sveltejs/kit':
-        specifier: ^2.55.0
-        version: 2.55.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.0)(vite@8.0.2(@types/node@25.5.0)))(svelte@5.55.0)(typescript@5.9.3)(vite@8.0.2(@types/node@25.5.0))
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -30,6 +27,9 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
+      '@sveltejs/kit':
+        specifier: ^2.69.3
+        version: 2.69.3(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.0)(vite@8.0.2(@types/node@25.5.0)))(svelte@5.55.0)(typescript@5.9.3)(vite@8.0.2(@types/node@25.5.0))
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -197,15 +197,15 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@sveltejs/kit@2.55.0':
-    resolution: {integrity: sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA==}
+  '@sveltejs/kit@2.69.3':
+    resolution: {integrity: sha512-cphwqMRcE19/9VkrIPr5qZhQ0SptSSDfDzRUpYHu9OJDFGuYBFyJzK+KQA27wB4YG32O/yF2QjBkDmTyo0vtCw==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
       '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0
       svelte: ^4.0.0 || ^5.0.0-next.0
-      typescript: ^5.3.3
+      typescript: ^5.3.3 || ^6.0.0
       vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0
     peerDependenciesMeta:
       '@opentelemetry/api':
@@ -368,6 +368,9 @@ packages:
 
   devalue@5.6.4:
     resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
+
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -924,7 +927,7 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.0)(vite@8.0.2(@types/node@25.5.0)))(svelte@5.55.0)(typescript@5.9.3)(vite@8.0.2(@types/node@25.5.0))':
+  '@sveltejs/kit@2.69.3(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.0)(vite@8.0.2(@types/node@25.5.0)))(svelte@5.55.0)(typescript@5.9.3)(vite@8.0.2(@types/node@25.5.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
@@ -932,7 +935,7 @@ snapshots:
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
-      devalue: 5.6.4
+      devalue: 5.8.1
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.21
@@ -1073,6 +1076,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   devalue@5.6.4: {}
+
+  devalue@5.8.1: {}
 
   es-module-lexer@2.0.0: {}
 


### PR DESCRIPTION
Bumps the **dev** SvelteKit to the latest (`@sveltejs/kit@^2.69.3`) so CI/build/typecheck run against current SvelteKit — the lockfile was pinning **2.55.0**, so we weren't actually testing against recent releases.

**The `peerDependency` is intentionally left at `^2.55.0`.** The library only uses long-stable APIs (`error`, and the `$app/server` remote functions `query`/`command`/`form`), so raising the peer floor would only force consumers on 2.55–2.68 to upgrade (pnpm-strict install errors / npm warnings) for no functional gain.

This is the first of two: a **follow-up PR will adopt newer remote-function features** (e.g. the `submitted` property from 2.69, `RemoteFormEnhanceInstance`/`RemoteFormEnhanceCallback` types from 2.68, the `exactOptionalPropertyTypes` form fix from 2.67) and *then* raise the peer floor to match — that break will be justified because the code will actually require it.

## Verified
Build, 107 runtime tests, and the type-check suite (which validates `RemoteFormInput` compatibility) all pass against SvelteKit 2.69.3. No version bump.