### PR TITLE
fix(runtime): no-arg action commands fail to type-check in consumers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .claude/
 *.tgz
 .DS_Store
+.gen-tc-*/

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -61,17 +61,20 @@ export function createRemoteHandlers(client: OpenapiClient) {
     return handleResponse(response, error, data);
   }
 
-  async function handlePostCommand(path: string, input: any) {
+  // `input` is optional so the no-argument action commands the generator emits for endpoints with
+  // no path params and no request body — `command(z.void(), async () => handlePostCommand(path))` —
+  // type-check (buildRequestOptions(undefined) yields no params and no body).
+  async function handlePostCommand(path: string, input?: any) {
     const { data, error, response } = await client.POST(path, buildRequestOptions(input));
     return handleResponse(response, error, data);
   }
 
-  async function handlePatchCommand(path: string, input: any) {
+  async function handlePatchCommand(path: string, input?: any) {
     const { data, error, response } = await client.PATCH(path, buildRequestOptions(input));
     return handleResponse(response, error, data);
   }
 
-  async function handlePutCommand(path: string, input: any) {
+  async function handlePutCommand(path: string, input?: any) {
     const { data, error, response } = await client.PUT(path, buildRequestOptions(input));
     return handleResponse(response, error, data);
   }

--- a/test/fixtures/edge-cases.d.ts
+++ b/test/fixtures/edge-cases.d.ts
@@ -1,0 +1,61 @@
+// Hand-written api.d.ts covering every command/query/form shape the generator emits, so the
+// "generated output type-checks" test exercises each against the real handler signatures.
+export interface paths {
+    "/items": {
+        get: operations["listItems"];       // GET (query)
+        post: operations["createItem"];     // no-path + body
+    };
+    "/items/{id}": {
+        patch: operations["updateItem"];    // path + body
+        delete: operations["deleteItem"];   // DELETE
+    };
+    "/items/{id}/archive": {
+        post: operations["archiveItem"];    // path + NO body  -> z.object({ path })
+    };
+    "/ping": {
+        post: operations["ping"];           // no-path + NO body -> z.void() (the regression case)
+    };
+    "/notes": {
+        post: operations["addNote"];        // no-path + OPTIONAL body
+    };
+    "/things/{id}": {
+        put: operations["replaceThing"];    // path + body (PUT)
+    };
+}
+export interface operations {
+    listItems: {
+        parameters: { query?: { limit?: number } };
+        responses: { 200: { content: { "application/json": { id: string }[] } } };
+    };
+    createItem: {
+        requestBody: { content: { "application/json": { name: string } } };
+        responses: { 201: { content: { "application/json": { id: string } } } };
+    };
+    updateItem: {
+        parameters: { path: { id: string } };
+        requestBody: { content: { "application/json": { name?: string } } };
+        responses: { 200: { content: { "application/json": { id: string } } } };
+    };
+    deleteItem: {
+        parameters: { path: { id: string } };
+        responses: { 200: { content: { "application/json": { ok: boolean } } } };
+    };
+    archiveItem: {
+        parameters: { path: { id: string } };
+        requestBody?: never;
+        responses: { 200: { content: { "application/json": { ok: boolean } } } };
+    };
+    ping: {
+        requestBody?: never;
+        responses: { 200: { content: { "application/json": { ok: boolean } } } };
+    };
+    addNote: {
+        requestBody?: { content: { "application/json": { text?: string } } };
+        responses: { 200: { content: { "application/json": { id: string } } } };
+    };
+    replaceThing: {
+        parameters: { path: { id: string } };
+        requestBody: { content: { "application/json": { value: number } } };
+        responses: { 200: { content: { "application/json": { id: string } } } };
+    };
+}

--- a/test/generated-typecheck.test.ts
+++ b/test/generated-typecheck.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { extractPaths, generateRemoteFiles } from '../src/generator.js';
+
+const LIB_ROOT = path.resolve(import.meta.dirname, '..');
+const FIXTURES = path.join(import.meta.dirname, 'fixtures');
+
+/**
+ * Compile the generator's OUTPUT against the real handler + type signatures — the gap that let a
+ * handler/generator arity mismatch (no-arg `z.void()` commands calling a 2-arg handler) ship in
+ * 0.1.9 despite green unit tests. The generator's string output and the runtime handlers were only
+ * tested separately; nothing checked that generated code actually type-checks in a consumer.
+ */
+describe('generated output type-checks against the real handlers', () => {
+  function typecheckFixture(fixture: string): { ok: boolean; out: string } {
+    const dir = fs.mkdtempSync(path.join(LIB_ROOT, '.gen-tc-'));
+    try {
+      const dts = fs.readFileSync(path.join(FIXTURES, fixture), 'utf8');
+      fs.writeFileSync(path.join(dir, 'api.d.ts'), dts);
+
+      const files = generateRemoteFiles(extractPaths(dts), {
+        output: dir, clientImport: './handlers', grouping: 'single', depth: 1,
+      });
+      for (const [name, content] of files) fs.writeFileSync(path.join(dir, name), content);
+
+      // Handlers wired from the REAL createRemoteHandlers — this is what makes an arity/signature
+      // mismatch between the generated calls and the handlers a compile error.
+      fs.writeFileSync(path.join(dir, 'handlers.ts'), [
+        `import { createRemoteHandlers } from 'sveltekit-openapi-remote';`,
+        `export const {`,
+        `  handleGetQuery, handlePostCommand, handlePatchCommand, handlePutCommand, handleDeleteCommand,`,
+        `  handlePostForm, handlePatchForm, handlePutForm, handleDeleteForm,`,
+        `} = createRemoteHandlers({} as never);`,
+        ``,
+      ].join('\n'));
+
+      // Minimal typed stub for SvelteKit's remote-function factories.
+      fs.writeFileSync(path.join(dir, 'app-server.ts'), [
+        `export function query<S, R>(_schema: S, fn: (input: any) => R): (arg?: any) => R { return fn; }`,
+        `export function command<S, R>(_schema: S, fn: (input: any) => R): (arg?: any) => R { return fn; }`,
+        `export function form<S, R>(_schema: S, fn: (input: any) => R): (arg?: any) => R { return fn; }`,
+        ``,
+      ].join('\n'));
+
+      fs.writeFileSync(path.join(dir, 'tsconfig.json'), JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          module: 'esnext',
+          moduleResolution: 'bundler',
+          noEmit: true,
+          skipLibCheck: true,
+          types: [],
+          baseUrl: '.',
+          paths: {
+            '$app/server': ['./app-server.ts'],
+            'sveltekit-openapi-remote': ['../src/index.ts'],
+          },
+        },
+        include: ['*.ts'],
+      }));
+
+      try {
+        execFileSync(path.join(LIB_ROOT, 'node_modules', '.bin', 'tsc'), ['-p', 'tsconfig.json'], {
+          cwd: dir, encoding: 'utf8',
+        });
+        return { ok: true, out: '' };
+      } catch (e) {
+        const err = e as { stdout?: string; stderr?: string };
+        return { ok: false, out: (err.stdout ?? '') + (err.stderr ?? '') };
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('compiles every command/query/form shape (edge-cases fixture incl. z.void())', () => {
+    const { ok, out } = typecheckFixture('edge-cases.d.ts');
+    expect(ok, `Generated output failed to type-check:\n${out}`).toBe(true);
+  });
+
+  it('compiles the petstore fixture', () => {
+    const { ok, out } = typecheckFixture('petstore.d.ts');
+    expect(ok, `Generated output failed to type-check:\n${out}`).toBe(true);
+  });
+});

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -133,6 +133,20 @@ describe('createRemoteHandlers', () => {
       await handlePostCommand('/billing/reactivate', undefined);
       expect(client.POST).toHaveBeenCalledWith('/billing/reactivate', {});
     });
+
+    it('is callable with only a path (no-arg action command shape)', async () => {
+      // The generator emits `command(z.void(), async () => handlePostCommand(path))` for no-path,
+      // no-body endpoints, i.e. a 1-argument call. `input` is optional so that type-checks.
+      const client = createMockClient();
+      client.POST.mockResolvedValue({
+        data: { ok: true },
+        error: undefined,
+        response: { ok: true, status: 200 },
+      });
+      const { handlePostCommand } = createRemoteHandlers(client as any);
+      await handlePostCommand('/billing/reactivate');
+      expect(client.POST).toHaveBeenCalledWith('/billing/reactivate', {});
+    });
   });
 
   describe('handlePatchCommand', () => {


### PR DESCRIPTION
Follow-up to #5. 0.1.9's generator emits a no-argument command for endpoints with **no path params and no request body**:

```ts
export const postBillingReactivateCommand = command(
  z.void(),
  async () => handlePostCommand('/billing/reactivate'),   // 1-argument call
);
```

But `handlePostCommand(path, input)` declared `input` as **required**, so the *generated* file itself failed to type-check in the consuming app:

```
error TS2554: Expected 2 arguments, but got 1.
```

(It worked at runtime — `input` was just `undefined` — so only type-check / CI was affected.)

## Fix
Make `input` optional on `handlePostCommand`/`handlePatchCommand`/`handlePutCommand`. `buildRequestOptions(undefined)` already yields no params and no body, so behavior is unchanged. **No regeneration needed** to adopt — existing 0.1.9 output type-checks as soon as the handler is optional.

## Verified
- Unit test: `handlePostCommand('/x')` (1 arg) → `client.POST('/x', {})`.
- Against a real consumer app: temporarily dropped in the built dist and re-ran `svelte-check` — the "Expected 2 arguments" errors went from N to **0**.
- Build + 108 tests + typecheck all green.

## Note
This slipped through because the library doesn't type-check its own *generated output* — only the generator's string output and the runtime handlers, separately. Worth a follow-up: compile a generated fixture in CI so consumer-facing type breaks are caught here. No version bump.