### PR TITLE
test: raise testTimeout to 30s for subprocess-spawning tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    // Several tests spawn slow subprocesses — the CLI tests run `openapi-typescript`, and the
+    // generated-output test runs `tsc`. Run in parallel on a contended CI runner these can exceed
+    // the 5s default, so give every test more headroom.
+    testTimeout: 30000,
     // Run the type-level assertions (test/types.test-d.ts) as real type checks — not no-op runtime
     // calls — so the GetRequestBody / schema-compatibility contracts are verified in CI alongside
     // the runtime suite. Uses tsconfig.test.json because the build tsconfig excludes test/.


### PR DESCRIPTION
Follow-up to #8. The CLI tests spawn `openapi-typescript` and the generated-output test (added in #8) spawns `tsc`. Run in parallel on a contended CI runner, these can exceed vitest's **5s** default — the `CLI --spec > generates from JSON spec` test timed out in CI. Raise the global `testTimeout` to **30s** so subprocess-heavy tests have headroom.

(This commit was pushed to #8's branch just after it merged, so it needs its own PR.)

Verified: full suite green (110 tests + typecheck); CI on #8 passed once this was applied.