### PR TITLE
Usability enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@standard-schema/spec": "^1.1.0",
     "@sveltejs/kit": "^2.69.3",
+    "@types/cross-spawn": "^6.0.6",
     "@types/node": "^25.5.0",
     "openapi-typescript": "^7.13.0",
     "typescript": "^5.3.3",
@@ -74,6 +75,7 @@
   "dependencies": {
     "chalk": "^5.6.2",
     "commander": "^14.0.3",
+    "cross-spawn": "^7.0.6",
     "ora": "^9.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       openapi-fetch:
         specifier: ^0.17.0
         version: 0.17.0
@@ -30,6 +33,9 @@ importers:
       '@sveltejs/kit':
         specifier: ^2.69.3
         version: 2.69.3(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.0)(vite@8.0.2(@types/node@25.5.0)))(svelte@5.55.0)(typescript@5.9.3)(vite@8.0.2(@types/node@25.5.0))
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -132,36 +138,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
     resolution: {integrity: sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==}
@@ -228,6 +240,9 @@ packages:
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/cross-spawn@6.0.6':
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -349,6 +364,10 @@ packages:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -365,9 +384,6 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
-
-  devalue@5.6.4:
-    resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
 
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
@@ -428,6 +444,9 @@ packages:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
     engines: {node: '>=0.10.0'}
@@ -481,24 +500,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -573,6 +596,10 @@ packages:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -606,6 +633,14 @@ packages:
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -770,6 +805,11 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -968,6 +1008,10 @@ snapshots:
 
   '@types/cookie@0.6.0': {}
 
+  '@types/cross-spawn@6.0.6':
+    dependencies:
+      '@types/node': 25.5.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -1065,6 +1109,12 @@ snapshots:
 
   cookie@0.6.0: {}
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
@@ -1074,8 +1124,6 @@ snapshots:
   deepmerge@4.3.1: {}
 
   detect-libc@2.1.2: {}
-
-  devalue@5.6.4: {}
 
   devalue@5.8.1: {}
 
@@ -1121,6 +1169,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   is-unicode-supported@2.1.0: {}
+
+  isexe@2.0.0: {}
 
   js-levenshtein@1.1.6: {}
 
@@ -1245,6 +1295,8 @@ snapshots:
       index-to-position: 1.2.0
       type-fest: 4.41.0
 
+  path-key@3.1.1: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -1289,6 +1341,12 @@ snapshots:
 
   set-cookie-parser@3.1.0: {}
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
@@ -1329,7 +1387,7 @@ snapshots:
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.6.4
+      devalue: 5.8.1
       esm-env: 1.2.2
       esrap: 2.2.4
       is-reference: 3.0.3
@@ -1402,6 +1460,10 @@ snapshots:
       '@types/node': 25.5.0
     transitivePeerDependencies:
       - msw
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,8 +27,15 @@ function getVersion(): string {
   return pkg.version;
 }
 
-function getNpxCommand(): string {
-  return process.platform === 'win32' ? 'npx.cmd' : 'npx';
+function getDlxCommand(): {executable: string, arguments: string[]} {
+  const ua = process.env.npm_config_user_agent ?? ''
+
+  if (ua.startsWith('pnpm/')) return { executable: `pnpm`, arguments: ['dlx'] };
+  if (ua.startsWith('npm/')) return { executable: `npm`, arguments: ['dlx'] };
+  if (ua.startsWith('yarn/')) return { executable: `yarn`, arguments: ['dlx'] };
+  if (ua.startsWith('bun/')) return { executable: `bunx`, arguments: [] };
+
+  throw new Error('unable to detect the package manager');
 }
 
 export function createProgram(): Command {
@@ -122,9 +129,10 @@ async function runGenerate(args: CliArgs): Promise<void> {
       fs.mkdirSync(args.output, { recursive: true });
     }
 
-    const result = spawn.sync(getNpxCommand(), ['openapi-typescript', args.spec, '-o', outputTypesPath], {
-        stdio: 'pipe',
-      });
+    const dlx = getDlxCommand();
+    const result = spawn.sync(dlx.executable, [...dlx.arguments, 'openapi-typescript', args.spec, '-o', outputTypesPath], {
+      stdio: 'pipe',
+    });
 
     if (result.error || result.status !== 0) {
       s.fail('openapi-typescript failed');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { Command, Option } from 'commander';
-import { execFileSync } from 'node:child_process';
+import spawn from 'cross-spawn';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -122,17 +122,18 @@ async function runGenerate(args: CliArgs): Promise<void> {
       fs.mkdirSync(args.output, { recursive: true });
     }
 
-    try {
-      execFileSync(getNpxCommand(), ['openapi-typescript', args.spec, '-o', outputTypesPath], {
+    const result = spawn.sync(getNpxCommand(), ['openapi-typescript', args.spec, '-o', outputTypesPath], {
         stdio: 'pipe',
       });
-      s.succeed(`Types generated ${chalk.dim(`→ ${outputTypesPath}`)}`);
-    } catch (e: any) {
+
+    if (result.error || result.status !== 0) {
       s.fail('openapi-typescript failed');
-      const stderr = e?.stderr?.toString().trim();
+      const stderr = result.stderr?.toString().trim();
       const detail = stderr ? `\n${stderr}` : '';
-      throw new Error(`openapi-typescript failed. Is it installed? (npm install -D openapi-typescript)${detail}`);
+      throw new Error(`openapi-typescript failed. Is it installed? (npm install -D openapi-typescript)${detail ? `\n${detail}` : ''}`);
     }
+
+    s.succeed(`Types generated ${chalk.dim(`→ ${outputTypesPath}`)}`);
 
     typesPath = outputTypesPath;
   }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -55,8 +55,24 @@ function buildRequestOptions(input: any) {
   };
 }
 
-export function createRemoteHandlers(client: OpenapiClient) {
+type OpenapiClientSource =
+  | OpenapiClient
+  | Promise<OpenapiClient>
+  | (() => OpenapiClient | Promise<OpenapiClient>);
+
+export function createRemoteHandlers(clientSource: OpenapiClientSource, cacheClient: boolean = true) {
+  let clientPromise: Promise<OpenapiClient> | undefined;
+  async function resolveClient(): Promise<OpenapiClient> {
+    if (!clientPromise || !cacheClient) {
+      clientPromise = Promise.resolve(
+        typeof clientSource === 'function' ? clientSource() : clientSource,
+      );
+    }
+    return clientPromise;
+  }
+
   async function handleGetQuery(path: string, params: any) {
+    const client = await resolveClient();
     const { data, error, response } = await client.GET(path, { params });
     return handleResponse(response, error, data);
   }
@@ -65,21 +81,25 @@ export function createRemoteHandlers(client: OpenapiClient) {
   // no path params and no request body — `command(z.void(), async () => handlePostCommand(path))` —
   // type-check (buildRequestOptions(undefined) yields no params and no body).
   async function handlePostCommand(path: string, input?: any) {
+    const client = await resolveClient();
     const { data, error, response } = await client.POST(path, buildRequestOptions(input));
     return handleResponse(response, error, data);
   }
 
   async function handlePatchCommand(path: string, input?: any) {
+    const client = await resolveClient();
     const { data, error, response } = await client.PATCH(path, buildRequestOptions(input));
     return handleResponse(response, error, data);
   }
 
   async function handlePutCommand(path: string, input?: any) {
+    const client = await resolveClient();
     const { data, error, response } = await client.PUT(path, buildRequestOptions(input));
     return handleResponse(response, error, data);
   }
 
   async function handleDeleteCommand(path: string, params: any) {
+    const client = await resolveClient();
     const { data, error, response } = await client.DELETE(path, { params });
     return handleResponse(response, error, data);
   }


### PR DESCRIPTION
Three changes in the PR:

1. using cross-spawn instead of execFileSync as it has better support for win32 and properly captures stdio etc. when spawning a child process on windows
2. Using pnpm with the --spec option was generally failing because it was hard-coding the use of npx. It now will infer what is being used, and invoke the appropriate dlx command
3. Passing an instance of OpenapiClient to `createRemoteHandlers` precluded the use of things like getRequestEvent. So it can now take a factory as well.